### PR TITLE
Use pyproject.toml to specify setup requirement and stop invoking pip from setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython", "numpy"]

--- a/setup.py
+++ b/setup.py
@@ -6,17 +6,8 @@ import subprocess
 
 from setuptools import setup, Extension
 
-setup_requires = ['numpy', 'cython']
-FNULL = open(os.devnull, 'w')
-subprocess.check_call(
-    ['pip', 'install', *setup_requires], stdout=FNULL, stderr=subprocess.STDOUT
-)
 from Cython.Distutils import build_ext
-try:
-    import numpy
-except ImportError:
-    print('numpy is required during installation')
-    sys.exit(1)
+import numpy
 
 
 DISTNAME = 'soft-dtw'


### PR DESCRIPTION
I think that invoking `pip` from `setup.py` is not a desirable way to ensure `numpy` and `Cython` are installed, because `pip` may not be in the `$PATH`, or in a different name (e.g. `pip3`), or a user want to install using `--user`.

By using `pyproject.toml` a build system can know build requirements without executing `setup.py` and install them appropriately. This feature was merged to `pip` in 2017 (https://github.com/pypa/pip/pull/4144) and I think it is okay to assume the availability of this feature now in 2020.
